### PR TITLE
Repurpose binary downloader script for all assets

### DIFF
--- a/.github/workflows/index.yaml
+++ b/.github/workflows/index.yaml
@@ -68,9 +68,10 @@ jobs:
         run: >
           # FIXME: Move indexing-tools to clangd org or wait for the merge with
           # clangd/clangd.
-          ./download_clangd_binaries.py
+          ./download_latest_release_assets.py
             --repository kirillbobyrev/indexing-tools
             --output-name clangd-linux.zip
+            --asset_prefix clangd-linux-snapshot
 
           unzip clangd-linux.zip
 

--- a/download_latest_release_assets.py
+++ b/download_latest_release_assets.py
@@ -7,13 +7,13 @@ import sys
 
 
 # Returns True if the download was successful.
-def download(repository, output_dir, target_os, output_name):
+def download(repository, asset_prefix, output_dir, output_name):
     # Traverse releases in chronological order.
     request = requests.get(
         f'https://api.github.com/repos/{repository}/releases')
     for release in request.json():
         for asset in release.get('assets', []):
-            if asset.get('name', '').startswith(f'clangd-{target_os}'):
+            if asset.get('name', '').startswith(asset_prefix):
                 download_url = asset['browser_download_url']
                 downloaded_file = requests.get(download_url)
                 if output_name is None:
@@ -36,21 +36,21 @@ def main():
         default='clangd/clangd')
     parser.add_argument('--output-dir',
                         type=str,
-                        help='Tools will be stored here.',
+                        help='Asset will be stored here.',
                         default=os.getcwd())
     parser.add_argument(
-        '--target-os',
+        '--output-name',
         type=str,
-        help='Operating system to download tools for. [default: linux]',
-        choices=['linux', 'mac', 'windows'],
-        default='linux')
-    parser.add_argument('--output-name',
-                        type=str,
-                        help=('Tools will be stored with this name, will use '
-                              'asset name by default'),
-                        default=None)
+        help=
+        'Asset will be stored with this name, will use asset name by default',
+        default=None)
+    parser.add_argument(
+        '--asset_prefix',
+        type=str,
+        help='The required prefix to match for asset to download.',
+        required=True)
     args = parser.parse_args()
-    success = download(args.repository, args.output_dir, args.target_os,
+    success = download(args.repository, args.asset_prefix, args.output_dir,
                        args.output_name)
     if not success:
         sys.exit(1)


### PR DESCRIPTION
This will enable us to use the same script for downloading indexing artifacts,
which doesn't start with `clangd-` prefix.

Also adds an output_name option to ease consumption of artifacts.
