### PR TITLE
Introduce container creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 # llvm-remote-index
 
 [![Index LLVM project](https://github.com/clangd/llvm-remote-index/workflows/Index%20LLVM%20project/badge.svg)](https://github.com/clangd/llvm-remote-index/actions)
+
+# Creating a docker image
+
+Running `bash deployment/create_docker_image.sh` will create a new container for
+index server. It will fetch the latest released server binary from
+[clangd/clangd/](github.com/clangd/clangd). The image is automatically tagged as
+llvm-remote-index-server:latest.
+
+Container will set up a cron job at startup to fetch latest LLVM index from
+[clangd/llvm-remote-index](https://github.com/clangd/llvm-remote-index) every 6
+hours. Afterwards it will start index-server, which will pick up the new index
+everytime it changes.

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -1,0 +1,17 @@
+FROM debian:stable
+RUN apt-get update && apt-get install -y cron python3 python3-requests unzip
+WORKDIR "/"
+
+ARG REPOSITORY
+ENV REPOSITORY ${REPOSITORY}
+ARG INDEX_ASSET_PREFIX
+ENV INDEX_ASSET_PREFIX ${INDEX_ASSET_PREFIX}
+ARG INDEXER_PROJECT_ROOT
+ENV INDEXER_PROJECT_ROOT ${INDEXER_PROJECT_ROOT}
+
+ADD "clangd-index-server" "clangd-index-server"
+ADD "download_latest_release_assets.py" "download_latest_release_assets.py"
+ADD "index_fetcher.sh" "index_fetcher.sh"
+ADD "entry_point.sh" "entry_point.sh"
+
+ENTRYPOINT ["/entry_point.sh"]

--- a/deployment/create_docker_image.sh
+++ b/deployment/create_docker_image.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+INDEX_REPO="clangd/llvm-remote-index"
+IMAGE_NAME="llvm-remote-index-server"
+INDEX_ASSET_PREFIX="llvm-index"
+SERVER_ASSET_PREFIX="clangd-indexing-tools-linux"
+OUTPUT_NAME="$SERVER_ASSET_PREFIX.zip"
+INDEXER_PROJECT_ROOT="/home/runner/work/llvm-remote-index/llvm-remote-index/llvm-project/"
+
+TEMP_DIR="$(mktemp -d)"
+# Make sure we delete TEMP_DIR on exit.
+trap "rm -r $TEMP_DIR" EXIT
+
+# Abort script on failure.
+set -e
+# Print commands as we execute them.
+set -x
+
+cp deployment/Dockerfile "$TEMP_DIR/"
+cp deployment/index_fetcher.sh "$TEMP_DIR/"
+cp deployment/entry_point.sh "$TEMP_DIR/"
+cp download_latest_release_assets.py "$TEMP_DIR/"
+
+cd "$TEMP_DIR"
+
+# First download and extract remote index server.
+./download_latest_release_assets.py \
+  --repository="clangd/clangd" \
+  --asset-prefix="$SERVER_ASSET_PREFIX" \
+  --output-name="$OUTPUT_NAME"
+# Only extract clangd-index-server.
+unzip -j "$OUTPUT_NAME" "*/bin/clangd-index-server"
+chmod +x clangd-index-server
+
+docker build --build-arg REPOSITORY="$INDEX_REPO" \
+  --build-arg INDEX_ASSET_PREFIX="$INDEX_ASSET_PREFIX" \
+  --build-arg INDEXER_PROJECT_ROOT="$INDEXER_PROJECT_ROOT" \
+  -t "$IMAGE_NAME" .

--- a/deployment/entry_point.sh
+++ b/deployment/entry_point.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+INDEX_FILE="/index.idx"
+INDEX_FETCHER_CMD="/index_fetcher.sh $REPOSITORY $INDEX_ASSET_PREFIX $INDEX_FILE"
+
+# Abort script on failure.
+set -e
+# Print commands as we execute them.
+set -x
+
+# Run index fetcher once every 6 hours.
+echo "0 */6 * * * $INDEX_FETCHER_CMD" > crontab_schedule.txt
+crontab crontab_schedule.txt
+cron
+
+# Fetch index once.
+$INDEX_FETCHER_CMD
+
+# Start the server.
+/clangd-index-server $INDEX_FILE $INDEXER_PROJECT_ROOT

--- a/deployment/index_fetcher.sh
+++ b/deployment/index_fetcher.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+REPO="$1"
+ASSET_PREFIX="$2"
+INDEX_FILE="$3"
+
+TEMP_DIR="$(mktemp -d)"
+# Make sure we delete TEMP_DIR on exit.
+trap "rm -r $TEMP_DIR" EXIT
+# Abort script on failure.
+set -e
+# Print commands as we execute them.
+set -x
+
+cd $TEMP_DIR
+/download_latest_release_assets.py --repository="$REPO" \
+  --asset-prefix="$ASSET_PREFIX" \
+  --output-name="index.zip"
+unzip "index.zip"
+mv *.idx $INDEX_FILE


### PR DESCRIPTION
Downloads latest index-server release and bundles it with artifact
downloader script to periodically(every 6 hours) download llvm index.

Built docker image, sets up a cron job for downloading the index and
then runs the clangd-index-server on default port.

Hopefully all of this infra can be used for any other project, only by
setting repo to fetch the index and asset name.
