### PR TITLE
Fetch indexing tools from clangd/clangd

### DIFF
--- a/.github/workflows/index.yaml
+++ b/.github/workflows/index.yaml
@@ -70,11 +70,11 @@ jobs:
           # clangd/clangd.
 
           ./download_latest_release_assets.py
-            --repository kirillbobyrev/indexing-tools
-            --output-name clangd-linux.zip
-            --asset-prefix clangd-linux-snapshot
+            --repository clangd/clangd
+            --output-name clangd-tools-linux.zip
+            --asset-prefix clangd-indexing-tools-linux
 
-          unzip clangd-linux.zip
+          unzip clangd-tools-linux.zip
 
           echo "CLANGD_INDEXER_BIN=$(find . -name 'clangd-indexer')"
             >> $GITHUB_ENV

--- a/.github/workflows/index.yaml
+++ b/.github/workflows/index.yaml
@@ -71,10 +71,10 @@ jobs:
 
           ./download_latest_release_assets.py
             --repository clangd/clangd
-            --output-name clangd-tools-linux.zip
+            --output-name clangd-indexing-tools.zip
             --asset-prefix clangd-indexing-tools-linux
 
-          unzip clangd-tools-linux.zip
+          unzip clangd-indexing-tools.zip
 
           echo "CLANGD_INDEXER_BIN=$(find . -name 'clangd-indexer')"
             >> $GITHUB_ENV


### PR DESCRIPTION
Once clangd/clangd starts releasing indexing tools (should be this Sunday) we can switch over to it.