### PR TITLE
Reduce disk space usage to fix broken builds

### DIFF
--- a/.github/workflows/index.yaml
+++ b/.github/workflows/index.yaml
@@ -49,7 +49,7 @@ jobs:
           repository: llvm/llvm-project
           path: llvm-project
           ref: ${{ steps.pick.output.sha }}
-      # Create compile_commands.json for the indexer and build generated files.
+      # Build generated files.
       - name: CMake
         run: >
           mkdir ${{ env.CLANGD_DIR }}
@@ -57,8 +57,6 @@ jobs:
           cmake -G Ninja -S llvm-project/llvm -B ${{ env.CLANGD_DIR }}
           "-DLLVM_ENABLE_PROJECTS=all"
           "-DCMAKE_BUILD_TYPE=Release"
-          "-DLLVM_ENABLE_ASSERTIONS=On"
-          "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
           "-DCMAKE_C_COMPILER=clang"
           "-DCMAKE_CXX_COMPILER=clang++"
       - name: Build generated files to ensure valid index
@@ -66,6 +64,16 @@ jobs:
           ninja -C ${{ env.CLANGD_DIR }} -t targets rule CUSTOM_COMMAND |
           grep -E "\.(cpp|h|inc)\$" |
           xargs ninja -C ${{ env.CLANGD_DIR }}
+      # Create compile_commands.json for the indexer: Debug build type is needed
+      # to index code behind #ifndef NDEBUG and enable assertions. At this point
+      # all source files were generated and all we need is new
+      # compile_commands.json.
+      - name: Generate compile_commands
+        run: >
+          cmake -G Ninja -S llvm-project/llvm -B ${{ env.CLANGD_DIR }}
+          "-DLLVM_ENABLE_PROJECTS=all"
+          "-DCMAKE_BUILD_TYPE=Debug"
+          "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
       - name: Fetch clangd-indexer
         run: >
           # FIXME: Move indexing-tools to clangd org or wait for the merge with


### PR DESCRIPTION
Recent indexing pipeline workflows were broken because of the
out-of-disk-space error. This was caused by Debug info taking too much
space and the fact that some generated files depend on actual libraries
and binaries which blows up the build size. Eventually we would like to
fix these generated files dependencies as they are unlikely to actually
need these libraries. However, we have no control over other projects'
dependency graphs and they can introduce some regresseions by depending
on some of LLVM/Clang libraries, too.

Hence, the solution is to

1. Build in Release mode: that reduces build size on disk and also makes
the build step faster. We only care about generated files here and they
are unlikely to differ between various build types.
2. Generate compile_commands.json using the Debug build configuration
and feed them to clangd-indexer. All the sources are generated in the
previous step and we are not running any build commands after CMake
regeneration. Having it in the same directory ensures the indexer can
find the needed files.