### PR TITLE
Create release only when all the work is done

### DIFF
--- a/.github/workflows/index.yaml
+++ b/.github/workflows/index.yaml
@@ -30,16 +30,6 @@ jobs:
           echo "RELEASE_COMMIT=$(git -C llvm-project rev-parse HEAD)" >> $GITHUB_ENV
           echo "RELEASE_COMMIT_SHORT=$(printf '%.12s' $(git -C llvm-project rev-parse HEAD))" >> $GITHUB_ENV
           echo "RELEASE_DATE=$(date -u +%Y%m%d)" >> $GITHUB_ENV
-      - name: Create release
-        uses: actions/create-release@v1
-        id: create_release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ env.RELEASE_COMMIT_SHORT }}
-          release_name: ${{ env.RELEASE_COMMIT_SHORT }}
-          body: |
-            Index snapshot built from llvm/llvm-project@${{ env.RELEASE_COMMIT }} on ${{ env.RELEASE_DATE }}.
       - name: Install system tools
         run: sudo apt-get install ninja-build build-essential swig python3-dev libedit-dev libncurses5-dev
       - name: Set environment variables
@@ -72,9 +62,6 @@ jobs:
           "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
       - name: Fetch clangd-indexer
         run: >
-          # FIXME: Move indexing-tools to clangd org or wait for the merge with
-          # clangd/clangd.
-
           ASSET_PREFIX="clangd_indexing_tools-linux"
 
           ./download_latest_release_assets.py
@@ -93,6 +80,16 @@ jobs:
       - name: Archive LLVM index
         run: >
           7z a llvm-index.zip llvm.idx
+      - name: Create release
+        uses: actions/create-release@v1
+        id: create_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.RELEASE_COMMIT_SHORT }}
+          release_name: ${{ env.RELEASE_COMMIT_SHORT }}
+          body: |
+            Index snapshot built from llvm/llvm-project@${{ env.RELEASE_COMMIT }} on ${{ env.RELEASE_DATE }}.
       - name: Upload generated index to release
         uses: actions/upload-release-asset@v1
         env: { GITHUB_TOKEN: "${{ secrets.RELEASE_TOKEN }}" }


### PR DESCRIPTION
Otherwise the indexing step might fail and we would be left with an empty release which is unfortunate.