### PR TITLE
Don't create release with token that might expire

### DIFF
--- a/.github/workflows/index.yaml
+++ b/.github/workflows/index.yaml
@@ -84,7 +84,7 @@ jobs:
         uses: actions/create-release@v1
         id: create_release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         with:
           tag_name: ${{ env.RELEASE_COMMIT_SHORT }}
           release_name: ${{ env.RELEASE_COMMIT_SHORT }}


### PR DESCRIPTION
Now that the release is created after the slow indexing step (#15), it's possible that GITHUB_TOKEN has expired when we go to create the release.

So use our long-lived token instead, just as we do for uploading assets.