### PR TITLE
Make use of date as the release tag

### DIFF
--- a/.github/workflows/index.yaml
+++ b/.github/workflows/index.yaml
@@ -86,8 +86,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         with:
-          tag_name: ${{ env.RELEASE_COMMIT_SHORT }}
-          release_name: ${{ env.RELEASE_COMMIT_SHORT }}
+          tag_name: index/${{ env.RELEASE_DATE }}
+          release_name: ${{ env.RELEASE_DATE }}
           body: |
             Index snapshot built from llvm/llvm-project@${{ env.RELEASE_COMMIT }} on ${{ env.RELEASE_DATE }}.
       - name: Upload generated index to release


### PR DESCRIPTION
GitHub releases page seems to be sorted on the descending semver ordering of
tags, in the case of commits associated with the releases having the same
creation time.
Since that's the case with index artifacts, by making use of date as release
tags, we somewhat gurantee having a fresh index.
